### PR TITLE
Adding arnassi ruins in the autotracking

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -255,7 +255,8 @@ function updateMap(area)
         sunkencity = "Sunken City",
         thebody = "The Body",
         theveil = "The Veil",
-        versecave = "Verse Cave"
+        versecave = "Verse Cave",
+        arnassiruins = "Arnassi Ruins"
     }
 
     local tabname = areaMap[area] or area  -- Convert area if it matches, otherwise keep original


### PR DESCRIPTION
This pull request is to add Arnassi ruins to the autotracking regions.

Note that the modifications in the `Archipelago:Get({PLAYERNUMBER...` lines is just vscode that have replace Windows end of lines to unix end of lines.