### PR TITLE
Renaming a location to fit the World and fix Li's cage access rules

### DIFF
--- a/locations/Aquaria.json
+++ b/locations/Aquaria.json
@@ -2631,14 +2631,14 @@
                         "name": "The Body center area, breaking Li's cage",
                         "item_count": 1,
                         "access_rules": [
-                            "tongue_removed"
+                            "sunkencity_boss"
                         ],
                         "visibility_rules": [
                             ""
                         ]
                     },
                     {
-                        "name": "The Body main area, bulb on the main path blocking tube",
+                        "name": "The Body center area, bulb on the main path blocking tube",
                         "item_count": 1,
                         "access_rules": [
                             ""


### PR DESCRIPTION
There was a bug for Breaking Li's cage location access rules. The Golem has to be beaten to be able to break the cage. For the latest AP world, the Tongue can be removed without beating the golem. That makes the location accessible, but since Li is still in the team, the cage cannot be broken. Beating the Golem make the creator lock Li in the cage. After that, the cage can be broken. Also, the Tongue requirement is already in the "body_c" area access rules. It is then not really necessary to put it also in the Li's cage access rules.